### PR TITLE
Add environment-specific storage configurations and custom tags support

### DIFF
--- a/azure-storage-module/main.tf
+++ b/azure-storage-module/main.tf
@@ -1,21 +1,17 @@
-provider "azurerm" {
-  features {}
-}
-
 locals {
   environment = terraform.workspace
   storage_config = {
     dev = {
       account_tier             = "Standard"
       account_replication_type = "LRS"
-      tags = {
+      base_tags = {
         environment = "development"
       }
     }
     prod = {
       account_tier             = "Standard"
       account_replication_type = "GRS"
-      tags = {
+      base_tags = {
         environment = "production"
       }
     }
@@ -28,5 +24,5 @@ resource "azurerm_storage_account" "storage" {
   location                 = var.location
   account_tier             = local.storage_config[local.environment].account_tier
   account_replication_type = local.storage_config[local.environment].account_replication_type
-  tags                     = local.storage_config[local.environment].tags
+  tags                     = merge(local.storage_config[local.environment].base_tags, var.additional_tags)
 }

--- a/azure-storage-module/variables.tf
+++ b/azure-storage-module/variables.tf
@@ -13,3 +13,9 @@ variable "location" {
   description = "Azure region location"
   default     = "eastus"
 }
+
+variable "additional_tags" {
+  type        = map(string)
+  description = "Additional tags for the storage account"
+  default     = {}
+}

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -1,0 +1,10 @@
+module "storage_account" {
+  source = "../../azure-storage-module"
+
+  storage_account_name = "devstorageaccount"
+  resource_group_name = "dev-rg"
+  location            = "eastus"
+  additional_tags     = {
+    project = "dev-project"
+  }
+}

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -1,0 +1,9 @@
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region"
+}

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -1,0 +1,10 @@
+module "storage_account" {
+  source = "../../azure-storage-module"
+
+  storage_account_name = "prodstorageaccount"
+  resource_group_name = "prod-rg"
+  location            = "eastus"
+  additional_tags     = {
+    project = "prod-project"
+  }
+}

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -1,0 +1,9 @@
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region"
+}


### PR DESCRIPTION
This PR implements environment-specific storage account configurations and adds support for custom tags. Key changes include:

- Added `additional_tags` variable to support custom tag injection
- Renamed `tags` to `base_tags` in storage configurations
- Implemented tag merging using `merge()` function to combine environment and custom tags
- Created dev and prod environment configurations with specific storage account settings
- Added environment-specific variable definitions
- Configured different replication types for dev (LRS) and prod (GRS) environments

The changes allow for more flexible tagging while maintaining environment-specific storage configurations and improving resource organization.